### PR TITLE
feat: middleware to restrict access to the console based on request origin.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -26,17 +26,17 @@ async function start({
 
   const app = new Koa();
   const wss = new WebSocketServer();
-
+  
   // Middleware to restrict access to the console based on request origin
   app.use(async (ctx, next) => {
-    if (ctx.path === '/' && ctx.headers.origin !== 'http://localhost') {
+    if (ctx.path === '/' && !['http://localhost', 'http://localhost:8080'].includes(ctx.headers.origin)) {
       ctx.status = 403;
       ctx.body = 'Access forbidden';
     } else {
       await next();
     }
   });
-
+    
   app.use(compress()).use(router(wss.channelManager, domain, cdn, basePath));
 
   if (server) {

--- a/server/index.js
+++ b/server/index.js
@@ -27,6 +27,16 @@ async function start({
   const app = new Koa();
   const wss = new WebSocketServer();
 
+  // Middleware to restrict access to the console based on request origin
+  app.use(async (ctx, next) => {
+    if (ctx.path === '/' && ctx.headers.origin !== 'http://localhost') {
+      ctx.status = 403;
+      ctx.body = 'Access forbidden';
+    } else {
+      await next();
+    }
+  });
+
   app.use(compress()).use(router(wss.channelManager, domain, cdn, basePath));
 
   if (server) {

--- a/server/middle/router.js
+++ b/server/middle/router.js
@@ -17,6 +17,16 @@ const maxAge = ms('2h');
 module.exports = function (channelManager, domain, cdn, basePath) {
   const router = new Router();
 
+  // Middleware to restrict access to the console based on request origin
+  router.use(async (ctx, next) => {
+    if (ctx.path === '/' && ctx.headers.origin !== 'http://localhost') {
+      ctx.status = 403;
+      ctx.body = 'Access forbidden';
+    } else {
+      await next();
+    }
+  });
+
   router.get(basePath, async ctx => {
     const tpl = await readTpl('index');
     ctx.body = tpl({

--- a/server/middle/router.js
+++ b/server/middle/router.js
@@ -19,7 +19,7 @@ module.exports = function (channelManager, domain, cdn, basePath) {
 
   // Middleware to restrict access to the console based on request origin
   router.use(async (ctx, next) => {
-    if (ctx.path === '/' && ctx.headers.origin !== 'http://localhost') {
+    if (ctx.path === '/' && !['http://localhost', 'http://localhost:8080'].includes(ctx.headers.origin)) {
       ctx.status = 403;
       ctx.body = 'Access forbidden';
     } else {


### PR DESCRIPTION
Add middleware to restrict access to the console based on request origin.

* In `server/index.js`, add middleware to restrict access to the console based on request origin, allowing WebSocket connections and `target.js` file to be accessed without restrictions.
* In `server/middle/router.js`, add middleware to restrict access to the console based on request origin, allowing WebSocket connections and `target.js` file to be accessed without restrictions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/liriliri/chii?shareId=96231c45-faaf-4134-8263-ef77869122d8).