### PR TITLE
default server to http://localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Use this script to inject the target code into your webpage.
 <script src="//host-machine-ip:8080/target.js"></script>
 ```
 
-Then browse to localhost:8080 to start debugging your page.
+Then browse to http://localhost:8080 to start debugging your page.
 
 For more detailed usage instructions, please read the documentation at [chii.liriliri.io](https://chii.liriliri.io/docs/)!
 

--- a/bin/chii.js
+++ b/bin/chii.js
@@ -11,7 +11,7 @@ program
   .description('starts chii server')
   .option('-p, --port <port>', 'set the port to start on. defaults to 8080', parseInt)
   .option('-h, --host <host>', 'set the host. defaults to 0.0.0.0')
-  .option('-d, --domain <domain>', 'set the domain. defaults to localhost:port')
+  .option('-d, --domain <domain>', 'set the domain. defaults to http://localhost:port')
   .option('--base-path <basePath>', 'set base path. defaults to /')
   .option('--cdn <cdn>', 'use cdn like jsdelivr')
   .option('--https', 'serve chii over https')

--- a/server/index.js
+++ b/server/index.js
@@ -19,7 +19,7 @@ async function start({
   sslKey,
   basePath = '/',
 } = {}) {
-  domain = domain || 'localhost:' + port;
+  domain = domain || 'http://localhost:' + port;
   if (!endWith(basePath, '/')) {
     basePath += '/';
   }


### PR DESCRIPTION
Sets the default server to http://localhost 

It makes it easy to open it in a browser with Ctrl+Click

```bash
$ npx chii start
starting server at http://localhost:8080/
```