### PR TITLE
fix: fix invalid route path in koa router

### DIFF
--- a/server/middle/router.js
+++ b/server/middle/router.js
@@ -64,7 +64,7 @@ module.exports = function (channelManager, domain, cdn, basePath) {
   });
 
   function createStatic(prefix, folder) {
-    router.get(`${basePath}${prefix}/*static`, async ctx => {
+    router.get(`${basePath}${prefix}/:staticPath(.*)`, async ctx => {
       await send(ctx, ctx.path.slice(basePath.length + prefix.length), {
         root: path.resolve(__dirname, `../..${folder}`),
         maxAge,


### PR DESCRIPTION
Fix the bug below when spinning up a server

```bash
bash-3.2$ chii start -p 8080
/opt/homebrew/lib/node_modules/chii/node_modules/path-to-regexp/dist/index.js:113
        throw new TypeError("Unexpected ".concat(nextType, " at ").concat(index, ", expected ").concat(type));
              ^

TypeError: Unexpected MODIFIER at 11, expected END
    at mustConsume (/opt/homebrew/lib/node_modules/chii/node_modules/path-to-regexp/dist/index.js:113:15)
    at parse (/opt/homebrew/lib/node_modules/chii/node_modules/path-to-regexp/dist/index.js:189:9)
    at stringToRegexp (/opt/homebrew/lib/node_modules/chii/node_modules/path-to-regexp/dist/index.js:346:27)
    at pathToRegexp (/opt/homebrew/lib/node_modules/chii/node_modules/path-to-regexp/dist/index.js:422:12)
    at new Layer (/opt/homebrew/lib/node_modules/chii/node_modules/koa-router/lib/layer.js:44:19)
    at Router.register (/opt/homebrew/lib/node_modules/chii/node_modules/koa-router/lib/router.js:471:19)
    at Router.<computed> [as get] (/opt/homebrew/lib/node_modules/chii/node_modules/koa-router/lib/router.js:814:10)
    at createStatic (/opt/homebrew/lib/node_modules/chii/server/middle/router.js:67:12)
    at module.exports (/opt/homebrew/lib/node_modules/chii/server/middle/router.js:84:3)
    at Object.start (/opt/homebrew/lib/node_modules/chii/server/index.js:30:27)
```

issue is due to malformed route pattern passed into koa-router, which internally uses path-to-regexp. 
This used to work in older versions of path-to-regexp, but now it's stricter. The *, +, ? characters (called modifiers) must be properly used — or escaped.