### PR TITLE
Add optional secret to websocket communication

### DIFF
--- a/bin/chii.js
+++ b/bin/chii.js
@@ -17,6 +17,7 @@ program
   .option('--https', 'serve chii over https')
   .option('--ssl-cert <cert>', 'provide an ssl certificate')
   .option('--ssl-key <key>', 'provide an ssl key')
+  .option('--secret <secret>', 'provide a secret')
   .action(options => {
     server.start(options);
   });

--- a/bin/chii.js
+++ b/bin/chii.js
@@ -17,7 +17,7 @@ program
   .option('--https', 'serve chii over https')
   .option('--ssl-cert <cert>', 'provide an ssl certificate')
   .option('--ssl-key <key>', 'provide an ssl key')
-  .option('--secret <secret>', 'provide a secret')
+  .option('--secrets <secret1,secret2...>', 'provide secrets', (value) => !value ? [] : value.split(','))
   .action(options => {
     server.start(options);
   });

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,7 @@ async function start({
   sslCert,
   sslKey,
   basePath = '/',
+  secret,
 } = {}) {
   domain = domain || 'localhost:' + port;
   if (!endWith(basePath, '/')) {
@@ -25,7 +26,7 @@ async function start({
   }
 
   const app = new Koa();
-  const wss = new WebSocketServer();
+  const wss = new WebSocketServer({ secret });
 
   app.use(compress()).use(router(wss.channelManager, domain, cdn, basePath));
 

--- a/server/index.js
+++ b/server/index.js
@@ -18,15 +18,14 @@ async function start({
   sslCert,
   sslKey,
   basePath = '/',
-  secret,
+  secrets = [],
 } = {}) {
   domain = domain || 'localhost:' + port;
   if (!endWith(basePath, '/')) {
     basePath += '/';
   }
-
   const app = new Koa();
-  const wss = new WebSocketServer({ secret });
+  const wss = new WebSocketServer( secrets );
 
   app.use(compress()).use(router(wss.channelManager, domain, cdn, basePath));
 

--- a/server/lib/WebSocketServer.js
+++ b/server/lib/WebSocketServer.js
@@ -4,7 +4,7 @@ const ChannelManager = require('./ChannelManager');
 const query = require('licia/query');
 
 module.exports = class WebSocketServer {
-  constructor() {
+  constructor({ secret }) {
     this.channelManager = new ChannelManager();
 
     const wss = (this._wss = new WebSocket.Server({ noServer: true }));
@@ -12,7 +12,13 @@ module.exports = class WebSocketServer {
     wss.on('connection', (ws, req) => {
       const type = ws.type;
       if (type === 'target') {
-        const { id, chiiUrl, title, favicon } = ws;
+        const { id, chiiUrl, title, favicon, secret: targetSecret } = ws;
+
+        if (secret && secret !== targetSecret) {
+          console.log('wrong secret provided');
+          ws.close();
+        }
+
         let ip = req.socket.remoteAddress;
         const userAgent = req.headers['user-agent'];
         if (req.headers['x-forwarded-for']) {
@@ -47,6 +53,7 @@ module.exports = class WebSocketServer {
             ws.favicon = q.favicon;
             ws.userAgent = q.userAgent;
             ws.rtc = q.rtc === 'true';
+            ws.secret = q.secret;
           } else {
             ws.target = q.target;
           }

--- a/server/lib/WebSocketServer.js
+++ b/server/lib/WebSocketServer.js
@@ -4,7 +4,7 @@ const ChannelManager = require('./ChannelManager');
 const query = require('licia/query');
 
 module.exports = class WebSocketServer {
-  constructor({ secret }) {
+  constructor( secrets ) {
     this.channelManager = new ChannelManager();
 
     const wss = (this._wss = new WebSocket.Server({ noServer: true }));
@@ -14,8 +14,11 @@ module.exports = class WebSocketServer {
       if (type === 'target') {
         const { id, chiiUrl, title, favicon, secret: targetSecret } = ws;
 
-        if (secret && secret !== targetSecret) {
-          console.log('wrong secret provided');
+        const isSecretRequired = Array.isArray(secrets) && secrets.length > 0;
+        const isSecretValid = targetSecret && secrets.includes(targetSecret);
+
+        if (isSecretRequired && !isSecretValid) {
+          console.log('wrong or no secret provided');
           ws.close();
         }
 

--- a/src/target/config.ts
+++ b/src/target/config.ts
@@ -31,6 +31,7 @@ if (!startWith(serverUrl, 'http')) {
 let embedded = false;
 let rtc = false;
 let cdn = '';
+let secret = '';
 
 const element = getTargetScriptEl();
 if (element) {
@@ -41,6 +42,7 @@ if (element) {
     rtc = true;
   }
   cdn = element.getAttribute('cdn') || '';
+  secret = element.getAttribute('secret') || '';
 }
 
 if (cdn && endWith(cdn, '/')) {
@@ -51,7 +53,7 @@ const sessionStore = safeStorage('session');
 
 let id = sessionStore.getItem('chii-id');
 if (!id) {
-  id = randomId(6);
+  id = randomId(32);
   sessionStore.setItem('chii-id', id);
 }
 
@@ -62,4 +64,5 @@ export {
   rtc,
   cdn,
   id,
+  secret,
 };

--- a/src/target/config.ts
+++ b/src/target/config.ts
@@ -64,5 +64,5 @@ export {
   rtc,
   cdn,
   id,
-  secret,
+  secret
 };

--- a/src/target/connectServer.ts
+++ b/src/target/connectServer.ts
@@ -1,7 +1,7 @@
 import Socket from 'licia/Socket';
 import query from 'licia/query';
 import chobitsu from 'chobitsu';
-import { serverUrl, id } from './config';
+import { serverUrl, id, secret } from './config';
 import { getFavicon } from './util';
 
 let isInit = false;
@@ -24,6 +24,7 @@ export default function () {
       title: (window as any).ChiiTitle || document.title,
       favicon: getFavicon(),
       '__chobitsu-hide__': true,
+      ...(secret ? { secret } : {}),
     })}`
   );
 


### PR DESCRIPTION
This change allows you to specify a secret that is checked when establishing a WebSocket connection. With this change, a client can only establish a connection if it specifies the correct secret. If no secret is specified, the application behaves as before.


How to test.

- Start server `npm run build && bin/chii.js start --secrets 333,444`
- Connect to it

With valid secret:
 ```javascript
(function () {
  var script = document.createElement('script');
  script.type = 'text/javascript';
  script.src = 'http://localhost:8080/target.js'; 
  script.setAttribute('secret', '333');
  document.getElementsByTagName('head')[0].appendChild(script);
})();

(function () {
  var script = document.createElement('script');
  script.type = 'text/javascript';
  script.src = 'http://localhost:8080/target.js'; 
  script.setAttribute('secret', '444');
  document.getElementsByTagName('head')[0].appendChild(script);
})();
```

With invalid secret:
 ```javascript
(function () {
  var script = document.createElement('script');
  script.type = 'text/javascript';
  script.src = 'http://localhost:8080/target.js'; 
  script.setAttribute('secret', '999');
  document.getElementsByTagName('head')[0].appendChild(script);
})();
```

With no secret:
 ```javascript
(function () {
  var script = document.createElement('script');
  script.type = 'text/javascript';
  script.src = 'http://localhost:8080/target.js'; 
  document.getElementsByTagName('head')[0].appendChild(script);
})();
```